### PR TITLE
(blacklist) Apply blacklist to Paizo Store.

### DIFF
--- a/chrome-extension/content/background.js
+++ b/chrome-extension/content/background.js
@@ -7,6 +7,7 @@ const PREFS = {
     blacklistRecruit: true,
     blacklistOOC: true,
     blacklistIC: false,
+    blacklistStore: true,
     useChat: true,
     chatPosition: '["25px","20px"]',
     useHighlighter: true,

--- a/chrome-extension/content/options.html
+++ b/chrome-extension/content/options.html
@@ -69,6 +69,10 @@
 					<input type="checkbox" class="pct-blacklist-control" id="pct-bl-ic" name="blacklistIC"/>
 					<label for="pct-bl-ic">Gameplay Threads</label>
 				</div>
+				<div class="checkbox">
+					<input type="checkbox" class="pct-blacklist-control" id="pct-bl-store" name="blacklistStore"/>
+					<label for="pct-bl-store">Product Threads</label>
+				</div>
 			</section>
 		</div>
 		<div class="right-column">

--- a/chrome-extension/content/options.js
+++ b/chrome-extension/content/options.js
@@ -7,6 +7,7 @@ const PREFS = {
     blacklistRecruit: true,
     blacklistOOC: true,
     blacklistIC: false,
+    blacklistStore: true,
     useChat: true,
     useHighlighter: true,
     highlightColor: "#ffaa00"
@@ -40,6 +41,7 @@ function loadOptions() {
         blacklistRecruit = localStorage["blacklistRecruit"],
         blacklistOOC = localStorage["blacklistOOC"],
         blacklistIC = localStorage["blacklistIC"],
+        blacklistStore = localStorage["blacklistStore"],
         blacklist = blacklistToArray(),
         useChat = localStorage["useChat"];
 
@@ -51,6 +53,7 @@ function loadOptions() {
     if (blacklistRecruit == "true") { document.getElementById('pct-bl-rec').setAttribute('checked', true); }
     if (blacklistOOC == "true") { document.getElementById('pct-bl-ooc').setAttribute('checked', true); }
     if (blacklistIC == "true") { document.getElementById('pct-bl-ic').setAttribute('checked', true); }
+    if (blacklistStore == "true") { document.getElementById('pct-bl-store').setAttribute('checked', true); }
     if (useChat) { document.getElementById('pct-use-chat').setAttribute('checked', true); }
     if (useHighlighter) { document.getElementById('pct-use-highlighter').setAttribute('checked', true); }
     document.getElementById('pct-highlight-color').value = highlightColor;

--- a/chrome-extension/content/pct.js
+++ b/chrome-extension/content/pct.js
@@ -208,17 +208,19 @@
         var blacklistNormal = blacklistPrefs.blacklistNormal,
             blacklistRecruit = blacklistPrefs.blacklistRecruit,
             blacklistOOC = blacklistPrefs.blacklistOOC,
-            blacklistIC = blacklistPrefs.blacklistIC;
+            blacklistIC = blacklistPrefs.blacklistIC,
+            blacklistStore = blacklistPrefs.blacklistStore;
 
         return (((document.location.href.indexOf("/threads/") >= 0) && blacklistNormal) ||
                 ((document.location.href.indexOf("/recruiting") >= 0) && blacklistRecruit) ||
                 ((document.location.href.indexOf("/discussion") >= 0) && blacklistOOC) ||
-                ((document.location.href.indexOf("/gameplay") >= 0) && blacklistIC));
+                ((document.location.href.indexOf("/gameplay") >= 0) && blacklistIC) ||
+                ((document.location.href.indexOf("/products") >= 0) && blacklistStore));
     }
 
     function updateBlacklist(evt) {
         pctBlacklist.blackListener(evt, function() {
-            chrome.runtime.sendMessage({storage: ['blacklistNormal', 'blacklistRecruit', 'blacklistOOC', 'blacklistIC', 'blacklistMethod', 'blacklist']}, function(response) {
+            chrome.runtime.sendMessage({storage: ['blacklistNormal', 'blacklistRecruit', 'blacklistOOC', 'blacklistIC', 'blacklistStore', 'blacklistMethod', 'blacklist']}, function(response) {
                 var blacklistPrefs = response.storage;
                 blacklistPosts(blacklistPrefs);
             });
@@ -245,7 +247,7 @@
         }
     });
 
-    chrome.runtime.sendMessage({storage: ['useBlacklist', 'blacklistNormal', 'blacklistRecruit', 'blacklistOOC', 'blacklistIC', 'blacklistMethod', 'blacklist']}, function(response) {
+    chrome.runtime.sendMessage({storage: ['useBlacklist', 'blacklistNormal', 'blacklistRecruit', 'blacklistOOC', 'blacklistIC', 'blacklistStore', 'blacklistMethod', 'blacklist']}, function(response) {
         var useBlacklist = response.storage.useBlacklist,
             blacklistMethod = response.storage.blacklistMethod,
             blacklistPrefs = response.storage;

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -17,6 +17,7 @@
         {
             "matches": ["http://paizo.com/people/*/campaigns",
                         "http://paizo.com/threads*", 
+			"http://paizo.com/products*",
                         "http://paizo.com/campaigns/*/gameplay*", 
                         "http://paizo.com/campaigns/*/discussion*",
                         "http://paizo.com/campaigns/*/recruiting*"],


### PR DESCRIPTION
- Extend the blacklist code to work on the Paizo Store.
- Add an option for it to the extension's options page.
