### PR TITLE
Add option to apply blacklist to blog comments.

### DIFF
--- a/chrome-extension/content/background.js
+++ b/chrome-extension/content/background.js
@@ -8,6 +8,7 @@ const PREFS = {
     blacklistOOC: true,
     blacklistIC: false,
     blacklistStore: true,
+    blacklistBlog: true,
     useChat: true,
     chatPosition: '["25px","20px"]',
     useHighlighter: true,

--- a/chrome-extension/content/options.html
+++ b/chrome-extension/content/options.html
@@ -73,6 +73,10 @@
 					<input type="checkbox" class="pct-blacklist-control" id="pct-bl-store" name="blacklistStore"/>
 					<label for="pct-bl-store">Product Threads</label>
 				</div>
+				<div class="checkbox">
+					<input type="checkbox" class="pct-blacklist-control" id="pct-bl-blog" name="blacklistBlog"/>
+					<label for="pct-bl-blog">Blog Threads</label>
+				</div>
 			</section>
 		</div>
 		<div class="right-column">

--- a/chrome-extension/content/options.js
+++ b/chrome-extension/content/options.js
@@ -8,6 +8,7 @@ const PREFS = {
     blacklistOOC: true,
     blacklistIC: false,
     blacklistStore: true,
+    blacklistBlog: true,
     useChat: true,
     useHighlighter: true,
     highlightColor: "#ffaa00"
@@ -42,6 +43,7 @@ function loadOptions() {
         blacklistOOC = localStorage["blacklistOOC"],
         blacklistIC = localStorage["blacklistIC"],
         blacklistStore = localStorage["blacklistStore"],
+        blacklistBlog = localStorage["blacklistBlog"],
         blacklist = blacklistToArray(),
         useChat = localStorage["useChat"];
 
@@ -54,6 +56,7 @@ function loadOptions() {
     if (blacklistOOC == "true") { document.getElementById('pct-bl-ooc').setAttribute('checked', true); }
     if (blacklistIC == "true") { document.getElementById('pct-bl-ic').setAttribute('checked', true); }
     if (blacklistStore == "true") { document.getElementById('pct-bl-store').setAttribute('checked', true); }
+    if (blacklistBlog == "true") { document.getElementById('pct-bl-blog').setAttribute('checked', true); }
     if (useChat) { document.getElementById('pct-use-chat').setAttribute('checked', true); }
     if (useHighlighter) { document.getElementById('pct-use-highlighter').setAttribute('checked', true); }
     document.getElementById('pct-highlight-color').value = highlightColor;

--- a/chrome-extension/content/pct.js
+++ b/chrome-extension/content/pct.js
@@ -209,18 +209,20 @@
             blacklistRecruit = blacklistPrefs.blacklistRecruit,
             blacklistOOC = blacklistPrefs.blacklistOOC,
             blacklistIC = blacklistPrefs.blacklistIC,
-            blacklistStore = blacklistPrefs.blacklistStore;
+            blacklistStore = blacklistPrefs.blacklistStore,
+            blacklistBlog = blacklistPrefs.blacklistBlog;
 
         return (((document.location.href.indexOf("/threads/") >= 0) && blacklistNormal) ||
                 ((document.location.href.indexOf("/recruiting") >= 0) && blacklistRecruit) ||
                 ((document.location.href.indexOf("/discussion") >= 0) && blacklistOOC) ||
                 ((document.location.href.indexOf("/gameplay") >= 0) && blacklistIC) ||
-                ((document.location.href.indexOf("/products") >= 0) && blacklistStore));
+                ((document.location.href.indexOf("/products") >= 0) && blacklistStore)) ||
+                ((document.location.href.indexOf("/blog") >= 0) && blacklistBlog));
     }
 
     function updateBlacklist(evt) {
         pctBlacklist.blackListener(evt, function() {
-            chrome.runtime.sendMessage({storage: ['blacklistNormal', 'blacklistRecruit', 'blacklistOOC', 'blacklistIC', 'blacklistStore', 'blacklistMethod', 'blacklist']}, function(response) {
+            chrome.runtime.sendMessage({storage: ['blacklistNormal', 'blacklistRecruit', 'blacklistOOC', 'blacklistIC', 'blacklistStore', 'blacklistBlog', 'blacklistMethod', 'blacklist']}, function(response) {
                 var blacklistPrefs = response.storage;
                 blacklistPosts(blacklistPrefs);
             });

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -17,7 +17,8 @@
         {
             "matches": ["http://paizo.com/people/*/campaigns",
                         "http://paizo.com/threads*", 
-			"http://paizo.com/products*",
+                        "http://paizo.com/products*",
+                        "http://paizo.com/*/blog*",
                         "http://paizo.com/campaigns/*/gameplay*", 
                         "http://paizo.com/campaigns/*/discussion*",
                         "http://paizo.com/campaigns/*/recruiting*"],


### PR DESCRIPTION
The blacklist doesn't work on the company and store blogs.
- Extend the blacklist to work on the blogs.
- Add an option to toggle blacklisting on the blogs.
- Extend the manifest to affect paizo.com/*/blog.
