### PR TITLE
Fix default alias selector to not override explicit selections when previewing

### DIFF
--- a/src/content/selector.js
+++ b/src/content/selector.js
@@ -38,13 +38,14 @@ window['pctSelector'] = (function(window) {
     }
 
     function isPostPreview() {
-        return (document.location.hash === '#newPost' || document.location.pathname.indexOf('createNewPost') >= 0);
+        return document.location.hash == '#newPost' ||
+               document.location.pathname.indexOf('createNewPost') >= 0;
     }
 
     function isReplyPreview() {
-        return (document.location.hash === '#newPost' || document.location.pathname.indexOf('createNewPost') >= 0) &&
-                document.location.search.indexOf("thread=") >= 0 &&
-                document.location.search.indexOf("post=") >= 0;
+        return isPostPreview() &&
+               document.location.search.indexOf("thread=") >= 0 &&
+               document.location.search.indexOf("post=") >= 0;
     }
 
     function selectAlias(campaigns, campaign) {

--- a/src/content/selector.js
+++ b/src/content/selector.js
@@ -37,6 +37,16 @@ window['pctSelector'] = (function(window) {
         return selected;
     }
 
+    function isPostPreview() {
+        return (document.location.hash === '#newPost' || document.location.pathname.indexOf('createNewPost') >= 0);
+    }
+
+    function isReplyPreview() {
+        return (document.location.hash === '#newPost' || document.location.pathname.indexOf('createNewPost') >= 0) &&
+                document.location.search.indexOf("thread=") >= 0 &&
+                document.location.search.indexOf("post=") >= 0;
+    }
+
     function selectAlias(campaigns, campaign) {
         chrome.runtime.sendMessage({storage: ['defaultAliases']}, function(response) {
             var defaultAliases = response.storage && response.storage.defaultAliases && JSON.parse(response.storage.defaultAliases) || {};
@@ -93,17 +103,20 @@ window['pctSelector'] = (function(window) {
     function updateSelect(select, alias, setDefault) {
         var options = select.options;
 
-        for (var i=0; i<options.length; i++) {
-            var option = options[i];
+        var selectDefaultAlias = !isPostPreview() || isReplyPreview();
+        if (selectDefaultAlias) {
+            for (var i = 0; i < options.length; i++) {
+                var option = options[i];
 
-            if (option.textContent == alias) {
-                setDefault.classList.add('inactive');
-                setDefault.title = 'This alias is your default for this campaign.';
-                option.setAttribute("selected", "selected");
-            } else if (option.getAttribute("selected")) {
-                option.removeAttribute("selected");
-            }
-        };
+                if (option.textContent == alias) {
+                    option.setAttribute("selected", "selected");
+                } else if (option.getAttribute("selected")) {
+                    option.removeAttribute("selected");
+                }
+            };
+        }
+        
+        select.onchange();
     }
 
     return {


### PR DESCRIPTION
This PR fixes the bug where the default alias selector will select a campaign's default alias, even when a user is previewing a post after having explicitly chosen an alternate alias.

To accomplish this, I added code to `updateSelect` to recognize when the current page is a preview of a new post, and to skip changing selection then. (If the page is a preview of a reply, the default alias is selected, as before).

I recommend viewing this PR with whitespace changes off, as the diff is simpler that way: https://github.com/oladon/PaizoCampaignTools/pull/4/files?w=1