### PR TITLE
Add old post indicator, to warn if replying to an old thread

### DIFF
--- a/src/content/background.js
+++ b/src/content/background.js
@@ -23,6 +23,9 @@ const PREFS = {
     nTPOn: "#ffaa00",
     nTPOff: "#4d3a98",
     useSelector: true,
+    useOldPostIndicator: true,
+    oldPostIndicatorAge: 1,
+    oldPostIndicatorUnit: 'year',
     useHeaderHider: true,
     hideHeader: false,
     useHeaderPM: "always"

--- a/src/content/oldpost.js
+++ b/src/content/oldpost.js
@@ -1,0 +1,56 @@
+window['pctOldPost'] = (function(window) {
+    function getLastPostDate() {
+        var lastDateTime = document.querySelector('div.bb-content > div > div:last-child time');
+        if (lastDateTime) {
+            return new Date(lastDateTime.getAttribute('datetime'));
+        }
+    }
+
+    function isMoreThanOneYearAgo(date) {
+        var oneYearAgo = new Date();
+        oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+        return date < oneYearAgo;
+    }
+
+    function formatDate(date) {
+        return date.toLocaleDateString();
+    }
+
+    function getPostBody() {
+        return document.getElementById('postBody');
+    }
+
+    function addIndicator(postBody, text) {
+        var indicator;
+
+        if (postBody) {
+            indicator = document.createElement('p');
+            indicator.innerHTML = text;
+            indicator.classList.add('tiny');
+            indicator.style.color = 'red';
+
+            var selectParent = postBody.parentNode;
+            selectParent.appendChild(indicator);
+        }
+
+        return indicator;
+    }
+
+    function addOldPostIndicator() {
+        chrome.runtime.sendMessage({}, function(response) {
+            var lastPostDate = getLastPostDate();
+            var postBody = getPostBody();
+            if (postBody && lastPostDate && isMoreThanOneYearAgo(lastPostDate)) {
+                var text =
+                    'Note: Last post in thread was ' +
+                    formatDate(lastPostDate) +
+                    ', more than 1 year ago.';
+                addIndicator(postBody, text);
+            }
+        });
+    }
+
+    return {
+        addOldPostIndicator: addOldPostIndicator
+    };
+})(window);

--- a/src/content/oldpost.js
+++ b/src/content/oldpost.js
@@ -6,10 +6,22 @@ window['pctOldPost'] = (function(window) {
         }
     }
 
-    function isMoreThanOneYearAgo(date) {
-        var oneYearAgo = new Date();
-        oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
-        return date < oneYearAgo;
+    function isMoreThanSpecifiedTimeAgo(date, age, unit) {
+        var specifiedTimeAgo = new Date();
+        switch (unit) {
+            case 'day':
+                specifiedTimeAgo.setDate(specifiedTimeAgo.getDate() - age);
+                break;
+            case 'month':
+                specifiedTimeAgo.setMonth(specifiedTimeAgo.getMonth() - age);
+                break;
+            case 'year':
+            default:
+                specifiedTimeAgo.setFullYear(specifiedTimeAgo.getFullYear() - age);
+                break;
+        }
+
+        return date < specifiedTimeAgo;
     }
 
     function formatDate(date) {
@@ -36,15 +48,16 @@ window['pctOldPost'] = (function(window) {
         return indicator;
     }
 
-    function addOldPostIndicator() {
+    function addOldPostIndicator(age, unit) {
         chrome.runtime.sendMessage({}, function(response) {
             var lastPostDate = getLastPostDate();
             var postBody = getPostBody();
-            if (postBody && lastPostDate && isMoreThanOneYearAgo(lastPostDate)) {
+            if (postBody && lastPostDate &&
+                isMoreThanSpecifiedTimeAgo(lastPostDate, age, unit)) {
                 var text =
                     'Note: Last post in thread was ' +
                     formatDate(lastPostDate) +
-                    ', more than 1 year ago.';
+                    ', more than ' + age + ' ' + unit + '(s) ago.';
                 addIndicator(postBody, text);
             }
         });

--- a/src/content/options.html
+++ b/src/content/options.html
@@ -66,6 +66,22 @@
                     Enable Extended Formatting Tags
                 </label>
             </section>
+            <section id="old-post-section">
+                <h3>Old Post Indicator</h3>
+                <label class="checkbox">
+                    <input type="checkbox" id="pct-use-old-post-indicator" name="useOldPostIndicator"/>
+                    Enable Old Post Indicator
+                </label>
+                <label class="checkbox">
+                    Highlight posts older than:
+                    <input type="text" id="pct-old-post-indicator-age" name="oldPostIndicatorAge" value="1" size="2"/>
+                    <select id="pct-old-post-indicator-unit" name="oldPostIndicatorUnit">
+                        <option value="day">day(s)</option>
+                        <option value="month">month(s)</option>
+                        <option value="year" selected>year(s)</option>
+                    </select>
+                </label>
+            </section>
             <section id="chat-section">
                 <h3>Chat</h3>
                 <label class="checkbox">

--- a/src/content/options.js
+++ b/src/content/options.js
@@ -29,6 +29,9 @@ function loadOptions() {
         nTPOn = localStorage["nTPOn"],
         nTPOff = localStorage["nTPOff"],
         useSelector = localStorage["useSelector"],
+        useOldPostIndicator = localStorage["useOldPostIndicator"],
+        oldPostIndicatorAge = localStorage["oldPostIndicatorAge"],
+        oldPostIndicatorUnit = localStorage["oldPostIndicatorUnit"],
         useHeaderHider = localStorage["useHeaderHider"],
         useHeaderPM = localStorage["useHeaderPM"];
 
@@ -52,6 +55,9 @@ function loadOptions() {
     if (useHighlighter == "true") { document.getElementById('pct-use-highlighter').setAttribute('checked', true); }
     document.getElementById('pct-highlight-color').value = highlightColor;
     if (useSelector == "true") { document.getElementById('pct-use-selector').setAttribute('checked', true); }
+    if (useOldPostIndicator == "true") { document.getElementById('pct-use-old-post-indicator').setAttribute('checked', true); }
+    document.getElementById('pct-old-post-indicator-age').value = oldPostIndicatorAge;
+    document.getElementById('pct-old-post-indicator-unit').value = oldPostIndicatorUnit;
     if (useInactives == "true") { document.getElementById('pct-use-inactives').setAttribute('checked', true); }
     if (useNeedToPost == "true") { document.getElementById('pct-use-need-to-post').setAttribute('checked', true); }
     document.getElementById('pct-ntp-active-color').value = nTPOn;
@@ -73,6 +79,7 @@ function loadOptions() {
     document.getElementById('pct-blacklist-add').addEventListener('click', addItemByDialog);
     document.getElementById('pct-blacklist-remove').addEventListener('click', deleteItems);
     document.getElementById('pct-clear-custom-avatars').addEventListener('click', clearCustomAvatars);
+    document.getElementById('pct-old-post-indicator-unit').addEventListener('change', saveOption);
 
     var inputs = document.getElementsByTagName('input');
     for (var i = 0; i<inputs.length; i++) {
@@ -103,7 +110,7 @@ function saveOption(evt) {
 
     if (target.type == "checkbox") {
         newValue = target.checked;
-    } else if ((target.type == "radio") || (target.type == "color")) {
+    } else if ((target.type == "radio") || (target.type == "color") || (target.tagName.toLowerCase() == "select")) {
         newValue = target.value;
     }
 

--- a/src/content/pct.js
+++ b/src/content/pct.js
@@ -301,11 +301,12 @@
             }
         });
 
-        chrome.runtime.sendMessage({storage: ['useChat', 'useExtendedFormatting', 'useNeedToPost', 'useSelector', 'campaigns']}, function(response = {storage: {}}) {
+        chrome.runtime.sendMessage({storage: ['useChat', 'useExtendedFormatting', 'useNeedToPost', 'useSelector', 'useOldPostIndicator', 'oldPostIndicatorAge', 'oldPostIndicatorUnit', 'campaigns']}, function(response = {storage: {}}) {
             const {
                 campaigns: storedCampaigns,
                 useChat, useExtendedFormatting,
-                useNeedToPost, useSelector
+                useNeedToPost, useSelector,
+                useOldPostIndicator, oldPostIndicatorAge, oldPostIndicatorUnit
             } = response.storage;
             var currentCampaign, storedCampaignsArray, pageCampaign;
 
@@ -313,9 +314,12 @@
                 storedCampaignsArray = JSON.parse(storedCampaigns);
             }
 
-            pctOldPost.addOldPostIndicator();
             pctFormatter.replaceTags(useExtendedFormatting);
             pctCampaigns.initialize(storedCampaignsArray);
+
+            if (useOldPostIndicator == "true") {
+                pctOldPost.addOldPostIndicator(oldPostIndicatorAge, oldPostIndicatorUnit);
+            }
 
             if (useNeedToPost == "true") {
                 pctNeedToPost.initialize(anyCampPage);

--- a/src/content/pct.js
+++ b/src/content/pct.js
@@ -10,6 +10,7 @@
     var pctFormatter = window.pctFormatter;
     var pctNeedToPost = window.pctNeedToPost;
     var pctSelector = window.pctSelector;
+    var pctOldPost = window.pctOldPost;
     var posts;
 
     var username = pctChat.getUsername(true) || undefined;
@@ -312,6 +313,7 @@
                 storedCampaignsArray = JSON.parse(storedCampaigns);
             }
 
+            pctOldPost.addOldPostIndicator();
             pctFormatter.replaceTags(useExtendedFormatting);
             pctCampaigns.initialize(storedCampaignsArray);
 

--- a/src/manifest.json.chrome
+++ b/src/manifest.json.chrome
@@ -48,6 +48,7 @@
                    "content/formatting.js",
                    "content/needtopost.js",
                    "content/selector.js",
+                   "content/oldpost.js",
                    "content/pct.js"]
         }
     ],

--- a/src/manifest.json.firefox
+++ b/src/manifest.json.firefox
@@ -66,6 +66,7 @@
                    "content/formatting.js",
                    "content/needtopost.js",
                    "content/selector.js",
+                   "content/oldpost.js",
                    "content/pct.js"],
             "run_at": "document_end"
         }

--- a/src/skin/options.css
+++ b/src/skin/options.css
@@ -175,7 +175,8 @@ section.subsection h4 {
     margin-left: -1em;
 }
 
-select[multiple] {
+input[type='text'],
+select {
     flex: .5 1 50%;
     font-size: 100%;
     padding: 0.5em 0.5em;


### PR DESCRIPTION
This PR adds an "old post indicator," to let people know they are replying to an old thread.

Example appearance:
<img width="454" alt="old post indicator example" src="https://user-images.githubusercontent.com/6874678/47252436-b4a0d200-d40a-11e8-86d1-7a836f7a7c3e.png">

The feature works by detecting the `time` element of the last post on a page. Since posting textareas only appear on the last page of a thread, this should always be the timestamp of the last post in the thread.

For now, the definition of "old" is that the last post is more than a year old, and this feature is always on. However I'd like to add options for both of these, if you like this feature overall.